### PR TITLE
Support NIP-50 search

### DIFF
--- a/src/cache_server_handlers.jl
+++ b/src/cache_server_handlers.jl
@@ -146,6 +146,26 @@ function initial_filter_handler(conn::Conn, subid, filters)
                 end
                 app_funcall(:events, [:event_ids=>eids], sendres; subid, ws_id=ws_id)
 
+            elseif haskey(filt, "search")
+                kinds = get(filt, "kinds", [1])
+                if kinds == [0] && !haskey(filt, "since") && !haskey(filt, "until")
+                    kwargs = [
+                        :query=>filt["search"],
+                        :limit=>get(filt, "limit", 10)
+                    ]
+                    app_funcall(:user_search, kwargs, sendres; subid, ws_id=ws_id)
+                elseif kinds == [1]
+                    kwargs = [
+                        :query=>filt["search"],
+                        :limit=>get(filt, "limit", 20),
+                        :since=>get(filt, "since", 0),
+                        :until=>get(filt, "until", nothing)
+                    ]
+                    app_funcall(:search, kwargs, sendres; subid, ws_id=ws_id)
+                else
+                    send_error("unsupported search filter")
+                end
+
             elseif haskey(filt, "since") || haskey(filt, "until")
                 kwargs = []
                 for a in ["since", "until", "limit", "idsonly"]


### PR DESCRIPTION
Related to #13 

Adds support for [NIP-50](https://github.com/nostr-protocol/nips/blob/master/50.md) search queries.

The following filters will work:

```jsonl
["REQ", "_", { "kinds": [0], "search": "alex", "limit": 5 }]
["REQ", "_", { "kinds": [1], "search": "hello" }]
["REQ", "_", { "search": "hello", "since": 0, "until": 1704225895165 }]
```

If you try to filter for unsupported kinds, it will error.

In the future, we should preprocess filters, and if a `search` filter doesn't have `kinds`, split it into two separate filters for `[0]` and `[1]`.